### PR TITLE
Use navigator.vibrate if possible

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -30,11 +30,21 @@ function haptic() {
 };
 
 haptic.confirm = () => {
+  if (navigator.vibrate) {
+    navigator.vibrate([50, 70, 50]);
+    return;
+  }
+
   haptic()
   setTimeout(() => haptic(), 120)
 }
 
 haptic.error = () => {
+  if (navigator.vibrate) {
+    navigator.vibrate([50, 70, 50, 70, 50]);
+    return;
+  }
+
   haptic()
   setTimeout(() => haptic(), 120)
   setTimeout(() => haptic(), 240)

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,11 @@
 
 function haptic() {
   try {
+    if (navigator.vibrate) {
+      navigator.vibrate(50);
+      return;
+    }
+
     const labelEl = document.createElement('label')
     labelEl.ariaHidden = 'true'
     labelEl.style.display = 'none'


### PR DESCRIPTION
Since navigator.vibrate is undefined on iOS, we can simply check if it exists.

With this update, this will be one comprehensive haptic library.
