### PR TITLE
feat: add framework bindings and trigger() API

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,44 +1,94 @@
 # 📳 ios-haptics
 
-javascript library for haptic feedback inside of safari on ios
+A lightweight JavaScript library for triggering haptic feedback in Safari on iOS — and on Android too.
 
 ![GitHub last commit](https://img.shields.io/github/last-commit/tijnjh/ios-haptics)
 [![npm version](https://img.shields.io/npm/v/ios-haptics.svg)](https://npmjs.com/package/ios-haptics)
 ![NPM Downloads](https://img.shields.io/npm/dm/ios-haptics)
 ![npm package minimized gzipped size](https://img.shields.io/bundlejs/size/ios-haptics)
 
-demo: [ios-haptics demo](https://codepen.io/tijnjh/pen/KwpgPqB)
+🎮 **[Live Demo on CodePen](https://codepen.io/tijnjh/pen/KwpgPqB)**
 
-## 📦 installation
+---
+
+## 📦 Installation
 
 ```sh
 npm i ios-haptics
 ```
 
-## 🚀 usage
+---
+
+## 🚀 Usage
+
+### Vanilla
+
+```javascript
+import { trigger } from 'ios-haptics'
+
+trigger()           // light tap
+trigger('success')  // two rapid taps
+trigger('error')    // three rapid taps
+trigger('warning')  // two rapid taps
+```
+
+Or use the classic API:
 
 ```javascript
 import { haptic } from 'ios-haptics'
 
-// a single haptic
-haptic()
-
-// two rapid haptics
-haptic.confirm()
-
-// three rapid haptics
-haptic.error()
+haptic()          // single tap
+haptic.confirm()  // two rapid taps
+haptic.error()    // three rapid taps
 ```
 
-## ⚙️ how it works
+### React
 
-this uses the `<input type="checkbox" switch />` (introduced in safari 17.4), which has haptic feedback when toggled
+```jsx
+import { useHaptics } from 'ios-haptics/react'
 
-every `haptic` call, it will create one of those in the background, toggle it, then remove it
+function App() {
+  const { trigger } = useHaptics()
+  return <button onClick={() => trigger('success')}>Tap me</button>
+}
+```
 
-on devices that support it, `navigator.vibrate()` is called instead, so it works on android too
+### Vue
+
+```vue
+<script setup>
+import { useHaptics } from 'ios-haptics/vue'
+const { trigger } = useHaptics()
+</script>
+
+<template>
+  <button @click="trigger('success')">Tap me</button>
+</template>
+```
+
+### Svelte
+
+```svelte
+<script>
+  import { haptic } from 'ios-haptics/svelte'
+</script>
+
+<!-- use as an action -->
+<button use:haptic={'success'}>Tap me</button>
+```
 
 ---
 
-feel free to send a pr or open an issue if you have suggestions or find
-improvements
+## ⚙️ How it works
+
+iOS Safari doesn't expose the Vibration API, but it *does* trigger haptic feedback when toggling a `<input type="checkbox" switch />` element — a feature introduced in Safari 17.4.
+
+Each call dynamically creates one of these inputs in the background, toggles it, and immediately removes it — giving you a clean, side-effect-free haptic tap.
+
+On Android, `navigator.vibrate()` is used instead, so it works cross-platform out of the box.
+
+---
+
+## 🤝 Contributing
+
+PRs and issues are welcome!

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ios-haptics",
   "type": "module",
-  "version": "0.1.4",
+  "version": "0.2.0",
   "description": "haptic feedback for ios safari",
   "author": "tijnjh",
   "license": "MIT",
@@ -13,12 +13,27 @@
     "haptic-feedback",
     "taptic",
     "safari",
-    "vibrate"
+    "vibrate",
+    "react",
+    "vue",
+    "svelte"
   ],
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/index.js"
+    },
+    "./react": {
+      "types": "./dist/react.d.ts",
+      "import": "./dist/react.js"
+    },
+    "./vue": {
+      "types": "./dist/vue.d.ts",
+      "import": "./dist/vue.js"
+    },
+    "./svelte": {
+      "types": "./dist/svelte.d.ts",
+      "import": "./dist/svelte.js"
     }
   },
   "main": "./dist/index.js",
@@ -30,6 +45,16 @@
   "scripts": {
     "build": "tsdown",
     "dev": "tsdown --watch"
+  },
+  "peerDependencies": {
+    "react": ">=17",
+    "svelte": ">=4",
+    "vue": ">=3"
+  },
+  "peerDependenciesMeta": {
+    "react": { "optional": true },
+    "vue": { "optional": true },
+    "svelte": { "optional": true }
   },
   "devDependencies": {
     "tsdown": "latest"

--- a/src/core.ts
+++ b/src/core.ts
@@ -1,0 +1,67 @@
+export const supportsHaptics =
+  typeof window === "undefined"
+    ? false
+    : window.matchMedia("(pointer: coarse)").matches;
+
+export type HapticType = "light" | "success" | "error" | "warning";
+
+function _single() {
+  try {
+    if (navigator.vibrate) {
+      navigator.vibrate(50);
+      return;
+    }
+
+    if (!supportsHaptics) return;
+
+    const labelEl = document.createElement("label");
+    labelEl.ariaHidden = "true";
+    labelEl.style.display = "none";
+
+    const inputEl = document.createElement("input");
+    inputEl.type = "checkbox";
+    inputEl.setAttribute("switch", "");
+    labelEl.appendChild(inputEl);
+
+    document.head.appendChild(labelEl);
+    labelEl.click();
+    document.head.removeChild(labelEl);
+  } catch {
+    // do nothing
+  }
+}
+
+function _confirm() {
+  if (navigator.vibrate) {
+    navigator.vibrate([50, 70, 50]);
+    return;
+  }
+  _single();
+  setTimeout(() => _single(), 120);
+}
+
+function _error() {
+  if (navigator.vibrate) {
+    navigator.vibrate([50, 70, 50, 70, 50]);
+    return;
+  }
+  _single();
+  setTimeout(() => _single(), 120);
+  setTimeout(() => _single(), 240);
+}
+
+export function trigger(type: HapticType = "light") {
+  switch (type) {
+    case "success":
+      return _confirm();
+    case "error":
+      return _error();
+    case "warning":
+      return _confirm();
+    case "light":
+    default:
+      return _single();
+  }
+}
+
+export { _single as singleHaptic, _confirm as confirmHaptic, _error as errorHaptic };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,93 +1,41 @@
-export const supportsHaptics =
-  typeof window === "undefined"
-    ? false
-    : window.matchMedia("(pointer: coarse)").matches;
+export { supportsHaptics, trigger } from "./core";
+export type { HapticType } from "./core";
+import { singleHaptic, confirmHaptic, errorHaptic } from "./core";
 
 function _haptic() {
-  try {
-    if (navigator.vibrate) {
-      navigator.vibrate(50);
-      return;
-    }
-
-    if (!supportsHaptics) return;
-
-    const labelEl = document.createElement("label");
-    labelEl.ariaHidden = "true";
-    labelEl.style.display = "none";
-
-    const inputEl = document.createElement("input");
-    inputEl.type = "checkbox";
-    inputEl.setAttribute("switch", "");
-    labelEl.appendChild(inputEl);
-
-    document.head.appendChild(labelEl);
-    labelEl.click();
-    document.head.removeChild(labelEl);
-  } catch {
-    // do nothing
-  }
+  singleHaptic();
 }
 
-_haptic.confirm = () => {
-  if (navigator.vibrate) {
-    navigator.vibrate([50, 70, 50]);
-    return;
-  }
-
-  _haptic();
-  setTimeout(() => _haptic(), 120);
-};
-
-_haptic.error = () => {
-  if (navigator.vibrate) {
-    navigator.vibrate([50, 70, 50, 70, 50]);
-    return;
-  }
-
-  _haptic();
-  setTimeout(() => _haptic(), 120);
-  setTimeout(() => _haptic(), 240);
-};
+_haptic.confirm = confirmHaptic;
+_haptic.error = errorHaptic;
 
 // prevent intellisense from being unhelpful
 interface haptic {
   /** @deprecated */
   apply: never;
-
   /** @deprecated */
   arguments: never;
-
   /** @deprecated */
   bind: never;
-
   /** @deprecated */
   call: never;
-
   /** @deprecated */
   caller: never;
-
   /** @deprecated */
   length: never;
-
   /** @deprecated */
   name: never;
-
   /** @deprecated */
   prototype: never;
-
   /** @deprecated */
   toString: never;
-
   /** @deprecated */
   Symbol: never;
 
-  /**  a single haptic */
+  /** a single haptic */
   (): void;
-
   /** two rapid haptics */
   confirm: () => void;
-
   /** three rapid haptics */
   error: () => void;
 }

--- a/src/react.ts
+++ b/src/react.ts
@@ -1,0 +1,12 @@
+import { useCallback } from "react";
+import { trigger } from "./core";
+import type { HapticType } from "./core";
+
+export function useHaptics() {
+  return {
+    trigger: useCallback((type?: HapticType) => trigger(type), []),
+  };
+}
+
+export { trigger };
+export type { HapticType };

--- a/src/svelte.ts
+++ b/src/svelte.ts
@@ -1,0 +1,25 @@
+import { trigger } from "./core";
+import type { HapticType } from "./core";
+
+export function useHaptics() {
+  return { trigger };
+}
+
+/** Svelte action — use:haptic */
+export function haptic(node: HTMLElement, type: HapticType = "light") {
+  function handler() {
+    trigger(type);
+  }
+  node.addEventListener("click", handler);
+  return {
+    update(newType: HapticType) {
+      type = newType;
+    },
+    destroy() {
+      node.removeEventListener("click", handler);
+    },
+  };
+}
+
+export { trigger };
+export type { HapticType };

--- a/src/vue.ts
+++ b/src/vue.ts
@@ -1,0 +1,9 @@
+import { trigger } from "./core";
+import type { HapticType } from "./core";
+
+export function useHaptics() {
+  return { trigger };
+}
+
+export { trigger };
+export type { HapticType };

--- a/tsdown.config.ts
+++ b/tsdown.config.ts
@@ -1,5 +1,4 @@
 import { defineConfig } from 'tsdown'
-
 import pkg from './package.json' with { type: 'json' }
 
 const banner = `/**
@@ -9,8 +8,14 @@ const banner = `/**
 **/`
 
 export default defineConfig({
-  entry: ['./src/index.ts', './src/index.d.ts'],
+  entry: [
+    './src/index.ts',
+    './src/react.ts',
+    './src/vue.ts',
+    './src/svelte.ts',
+  ],
   platform: 'neutral',
   outputOptions: { banner },
   dts: true,
+  external: ['react', 'vue', 'svelte'],
 })


### PR DESCRIPTION
## What's new

- `trigger(type)` API with `light` / `success` / `error` / `warning` types
- `ios-haptics/react` — `useHaptics()` hook
- `ios-haptics/vue` — `useHaptics()` composable
- `ios-haptics/svelte` — `useHaptics()` + `use:haptic` action
- Refactored core into `src/core.ts`
- Bumped to v0.2.0

Existing `haptic()` API is fully preserved.